### PR TITLE
fix: SIGTERM is ignored sometimes, log file update

### DIFF
--- a/bin/killserver
+++ b/bin/killserver
@@ -21,7 +21,7 @@ kill_node_instances() {
 
     # Kill all existing Node PIDs.
     for pid in $node_instances;
-      do kill -15 $pid || true;
+      do kill -9 $pid || true;
     done
 
     echo "Killed node instances."

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -114,10 +114,10 @@ pipeline {
 
               // All log statements should have been piped to their respective
               // files. The contents are also displayed in the console.
-              echo "Server start output log:"
-              sh "cat logs/stdout.log"
-              echo "Server start error log:"
-              sh "cat logs/stderr.log"
+              //echo "Server start output log:"
+              //sh "cat logs/stdout.log"
+              //echo "Server start error log:"
+              //sh "cat logs/stderr.log"
           }
       }
       stage('Prune and Cleanup') {


### PR DESCRIPTION
This fix addresses an issue where the node process was not always being killed using a SIGTERM.  Switched over to a SIGKILL to ensure the process is killed before restarting server on the designated port.

There was also a problem with the jenkins file trying to print the contents of two log files that never existed.  Not sure why this started causing a problem all of a sudden since the code hasn't changed since over the past few months.